### PR TITLE
fix: reorder docker steps, add teraform lifecycle trigger when redepoying ACR

### DIFF
--- a/ai_server_example/blindbox.tf
+++ b/ai_server_example/blindbox.tf
@@ -171,8 +171,8 @@ resource "azurerm_resource_group_template_deployment" "container" {
                       "memoryInGB" : local.memory_in_gb
                     }
                   },
-                  "securityContext": {
-                      "privileged": true
+                  "securityContext" : {
+                    "privileged" : true
                   }
                 }
               }
@@ -206,6 +206,12 @@ resource "azurerm_resource_group_template_deployment" "container" {
   depends_on = [
     null_resource.docker_push
   ]
+
+  lifecycle {
+    # Updating the deployment in-place does not work when the ACR
+    # is redeployed, apparently.
+    replace_triggered_by = [azurerm_container_registry.acr]
+  }
 
   deployment_mode = "Incremental"
 }

--- a/client/blindbox/command/azure-sev/Dockerfile
+++ b/client/blindbox/command/azure-sev/Dockerfile
@@ -1,15 +1,20 @@
 FROM debian:bullseye
 
+# Base image
+
 ARG EMBED_IMAGE_TAR
 
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /root
 
 COPY ./sev-init.sh /root
-COPY ./sev-start.sh /root
 
 RUN ./sev-init.sh
 
+# Start of deployment-specific content
+
 COPY ${EMBED_IMAGE_TAR} /root/container.tar
+
+COPY ./sev-start.sh /root
 
 CMD ./sev-start.sh

--- a/client/blindbox/command/azure-sev/template.tf
+++ b/client/blindbox/command/azure-sev/template.tf
@@ -171,8 +171,8 @@ resource "azurerm_resource_group_template_deployment" "container" {
                       "memoryInGB" : local.memory_in_gb
                     }
                   },
-                  "securityContext": {
-                      "privileged": true
+                  "securityContext" : {
+                    "privileged" : true
                   }
                 }
               }
@@ -206,6 +206,12 @@ resource "azurerm_resource_group_template_deployment" "container" {
   depends_on = [
     null_resource.docker_push
   ]
+
+  lifecycle {
+    # Updating the deployment in-place does not work when the ACR
+    # is redeployed, apparently.
+    replace_triggered_by = [azurerm_container_registry.acr]
+  }
 
   deployment_mode = "Incremental"
 }


### PR DESCRIPTION
Some tweaks I had laying around, backported to main.

1. Reorder docker steps
This helps docker cache, as we dont need to rerun sev-init.sh when rebuilding.

2. Updating the containers group deployment in-place does not work when the ACR is redeployed, apparently.
Added a lifecycle trigger to force replace.