### PR TITLE
ci dependencies versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install pypi dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install aiohttp requests jwt coverage pyyaml pydantic rich inquirer
+          python -m pip install aiohttp requests jwt coverage "pyyaml>=6.0" "pydantic>=1.10.7, <2" "rich>=13.3.5" "inquirer>=3.1"
 
       - name: Coverage testing
         run: |
@@ -84,7 +84,7 @@ jobs:
         run: |
           python -c "import sys; print('Python version:', sys.version)"
           python -m pip install --upgrade pip
-          python -m pip install pydantic inquirer rich pyyaml
+          python -m pip install "pydantic>=1.10.7, <2" "inquirer>=3.1" "rich>=13.3.5" "pyyaml>=6.0"
 
       - name: Client build
         run: |


### PR DESCRIPTION
Fix CI pydantic version error.
In version 2, [pattern](https://github.com/pydantic/pydantic/blob/8466f78da6b42d404fa721be6b3f57061b99cb30/pydantic/types.py#L274) replaces the `regex` argument used in [builder.py](https://github.com/mithril-security/blindbox/blob/64498f869526d6c0390caf2facbb52727d2d1359/client/blindbox/command/builder.py#L35):
```bash
IPModel = pydantic.constr(regex="^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")

TypeError: constr() got an unexpected keyword argument 'regex'
```